### PR TITLE
Change package.json to be able to build on windows 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   },
   "scripts": {
     "clean": "rimraf ./dist",
-    "dist": "npm run clean && ./node_modules/.bin/tsc",
+    "build": "tsc",
+    "dist": "npm run build",
+    "rebuild": "npm run clean && npm run dist",
     "start": "node ./zenbot.js",
     "start:dev": "NODE_ENV=development node ./zenbot.js"
   },


### PR DESCRIPTION
To be able to run `npm run dist` on windows, the following changes had to be applied.
It works for a installed (non global) tsc. Npm takes care by itself if tsc is usable from global or local node_modules cache.

I have also added a rebuild script, that just combines clean & dist for a "fast" rebuild.