### PR TITLE
Add cross-env to enable env vars on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dist": "npm run build",
     "rebuild": "npm run clean && npm run dist",
     "start": "node ./zenbot.js",
-    "start:dev": "NODE_ENV=development node ./zenbot.js"
+    "start:dev": "cross-env NODE_ENV=development node ./zenbot.js"
   },
   "dependencies": {
     "@slack/client": "^4.1.0",
@@ -34,6 +34,7 @@
     "colors": "^1.2.1",
     "convnetjs": "0.3.0",
     "counterup": "^1.0.2",
+    "cross-env": "5.2.0",
     "ejs": "^2.5.8",
     "forex.analytics": "github:mkmarek/forex.analytics#7bc278987700d4204e959af17de61495941d1a14",
     "gdax": "^0.8.0",


### PR DESCRIPTION
On Windows its not allowed to set environment variables with a prefixed ENV_VAR=VALUE.
To be compatible with windows this has to be workarounded.