### PR TITLE
Add EventBus

### DIFF
--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -2,8 +2,8 @@ jest.mock('pushbullet')
 jest.mock('crypto', () => ({ randomBytes: () => ({ toString: () => 'random-string' }) }))
 
 jest.mock('../../src/lib/ws-server', () => {
-  const wsServer = {}
-  return { wsServer }
+  const WsServer = class {}
+  return { WsServer }
 })
 
 jest.mock('../../src/lib/db/db-driver.lib', () => {

--- a/src/lib/event-bus.spec.ts
+++ b/src/lib/event-bus.spec.ts
@@ -1,0 +1,61 @@
+import { EventBus, EVENT } from './event-bus'
+
+describe('EventBus', () => {
+  let eventBus: EventBus
+
+  beforeEach(() => {
+    eventBus = new EventBus()
+  })
+
+  it('should register new emitters', (done) => {
+    const emitter = eventBus.register({ event: EVENT.TRADE, exchange: 'test' })
+    expect(emitter).toBeDefined()
+    expect(typeof emitter).toEqual('function')
+    done()
+  })
+
+  it('should subscribe to events', (done) => {
+    const eventBusEvent = { event: EVENT.TRADE, exchange: 'test' }
+    eventBus.register(eventBusEvent)
+
+    // tslint:disable-next-line
+    const subscriber = eventBus.subscribe(eventBusEvent, (data) => {})
+
+    expect(subscriber).toBeDefined()
+    expect(typeof subscriber).toEqual('function')
+    done()
+  })
+
+  it('should emit event data', (done) => {
+    const eventBusEvent = { event: EVENT.TRADE, exchange: 'test' }
+    const emitter = eventBus.register(eventBusEvent)
+
+    const onData = jest.fn()
+    eventBus.subscribe(eventBusEvent, onData)
+
+    const foo = 'bar'
+    emitter({ foo })
+
+    setImmediate(() => {
+      expect(onData).toHaveBeenCalledWith({ foo })
+      done()
+    })
+  })
+
+  it('should not emit data to unsubs', (done) => {
+    const eventBusEvent = { event: EVENT.TRADE, exchange: 'test' }
+    const emitter = eventBus.register(eventBusEvent)
+
+    const onData = jest.fn()
+    const subscriber = eventBus.subscribe(eventBusEvent, onData)
+
+    const foo = 'bar'
+    subscriber()
+    emitter({ foo })
+
+    setImmediate(() => {
+      expect(onData).not.toHaveBeenCalled()
+      done()
+    })
+  })
+})

--- a/src/lib/event-bus.spec.ts
+++ b/src/lib/event-bus.spec.ts
@@ -14,15 +14,28 @@ describe('EventBus', () => {
     done()
   })
 
+  it('should throw if register with invalid opts', (done) => {
+    expect(() => eventBus.register({ event: EVENT.TRADE, exchange: 'test', strategy: 'test' })).toThrowError()
+    done()
+  })
+
   it('should subscribe to events', (done) => {
     const eventBusEvent = { event: EVENT.TRADE, exchange: 'test' }
     eventBus.register(eventBusEvent)
 
-    // tslint:disable-next-line
+    // tslint:disable-next-line:no-empty
     const subscriber = eventBus.subscribe(eventBusEvent, (data) => {})
 
     expect(subscriber).toBeDefined()
     expect(typeof subscriber).toEqual('function')
+    done()
+  })
+
+  it('should throw if subscribe with invalid opts', (done) => {
+    expect(() =>
+      // tslint:disable-next-line:no-empty
+      eventBus.subscribe({ event: EVENT.TRADE, exchange: 'test', strategy: 'test' }, (data) => {})
+    ).toThrowError()
     done()
   })
 

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -21,15 +21,21 @@ type SelectorMap = Map<string, StrategyMap>
 type ExchangeMap = Map<string, SelectorMap>
 type EventMap = Map<EVENT, ExchangeMap>
 
+const optsErr = 'selector is required if strategy is defined'
+
 export class EventBus {
   private eventMap: EventMap = new Map()
 
   public register(eventBusEvent: EventBusEvent) {
+    if (eventBusEvent.strategy && !eventBusEvent.selector) throw new Error(optsErr)
+
     // pop onto next callstack
     return (eventData: EventData) => setImmediate(() => this.emit(eventBusEvent, eventData))
   }
 
   public subscribe(eventBusEvent: EventBusEvent, fn: EventDataFn) {
+    if (eventBusEvent.strategy && !eventBusEvent.selector) throw new Error(optsErr)
+
     const set = this.makeSet(eventBusEvent)
     set.add(fn)
 

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -1,0 +1,84 @@
+export enum EVENT {
+  PERIOD = 'period',
+  TRADE = 'trade',
+  ORDER = 'order',
+  BOOK = 'book',
+}
+
+interface EventBusEvent {
+  event: EVENT
+  exchange: string
+  selector?: string
+  strategy?: string
+}
+
+type EventData = Record<string, any>
+type EventDataFn = (data: EventData) => void
+
+type EventDataSet = Set<EventDataFn>
+type StrategyMap = Map<string, EventDataSet>
+type SelectorMap = Map<string, StrategyMap>
+type ExchangeMap = Map<string, SelectorMap>
+type EventMap = Map<EVENT, ExchangeMap>
+
+export class EventBus {
+  private eventMap: EventMap = new Map()
+
+  public register(eventBusEvent: EventBusEvent) {
+    // pop onto next callstack
+    return (eventData: EventData) => setImmediate(() => this.emit(eventBusEvent, eventData))
+  }
+
+  public subscribe(eventBusEvent: EventBusEvent, fn: EventDataFn) {
+    const set = this.makeSet(eventBusEvent)
+    set.add(fn)
+
+    return () => set.delete(fn)
+  }
+
+  private emit({ event, exchange, selector = 'all', strategy = 'all' }: EventBusEvent, eventData: EventData) {
+    const set = this.getSet({ event, exchange, selector, strategy })
+    if (!set) return
+
+    set.forEach((fn) => fn(eventData))
+
+    if (selector !== 'all') {
+      this.emit({ event, exchange, selector: 'all', strategy: 'all' }, eventData)
+    } else if (strategy !== 'all') {
+      this.emit({ event, exchange, selector, strategy: 'all' }, eventData)
+    }
+  }
+
+  private makeSet({ event, exchange, selector = 'all', strategy = 'all' }: EventBusEvent) {
+    const set = this.getSet({ event, exchange, selector, strategy })
+    if (set) return set
+
+    if (!this.eventMap.has(event)) this.eventMap.set(event, new Map())
+
+    const exchangeMap = this.eventMap.get(event)
+    if (!exchangeMap.has(exchange)) exchangeMap.set(exchange, new Map())
+
+    const selectorMap = exchangeMap.get(exchange)
+    if (!selectorMap.has(selector)) selectorMap.set(selector, new Map())
+
+    const strategyMap = selectorMap.get(selector)
+    if (!strategyMap.has(strategy)) strategyMap.set(strategy, new Set())
+
+    return strategyMap.get(strategy)
+  }
+
+  private getSet({ event, exchange, selector = 'all', strategy = 'all' }: EventBusEvent) {
+    if (!this.eventMap.has(event)) return false
+
+    const exchangeMap = this.eventMap.get(event)
+    if (!exchangeMap.has(exchange)) return false
+
+    const selectorMap = exchangeMap.get(exchange)
+    if (!selectorMap.has(selector)) return false
+
+    const strategyMap = selectorMap.get(selector)
+    if (!strategyMap.has(strategy)) return false
+
+    return strategyMap.get(strategy)
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,8 @@
+import { EventBus } from './event-bus'
+export const eventBus = new EventBus()
+
+import { WsServer } from './ws-server'
+export const wsServer = new WsServer()
+
 export * from './db'
 export * from './core'
-export * from './ws-server'

--- a/src/lib/ws-server.ts
+++ b/src/lib/ws-server.ts
@@ -2,7 +2,7 @@ import WebSocket from 'ws'
 
 type Payload = Record<string, any>
 
-class WsServer {
+export class WsServer {
   private server: WebSocket.Server
   private actions: Map<string, (payload: Payload) => void> = new Map()
 
@@ -39,5 +39,3 @@ class WsServer {
     }
   }
 }
-
-export const wsServer = new WsServer()


### PR DESCRIPTION
This PR adds a global EventBus. It's a basic pub/sub system.

## Register

A data source will register with the event bus, the event type and exchange are required but the selector and strategy are optional. The register function is a higher order function that returns an emitter.

If the selector is omitted then this emitter will send events to all subscribers of type and exchange.
If the strategy is omitted then this subscriber will send events to all subscribers of type, exchange, and selector.

```typescript
const emitter = eventBus.register(eventBusEvent)

// Somewhere else in the code
emitter({ foo: 'bar' })
```

## Subscribe

A data destination can subscribe to events, the event type and exchange are required but the selector and strategy are optional. The subscribe function returns an unsubscribe function.

If the selector is omitted then this subscriber will receive all events for the type and exchange.
If the strategy is omitted then this subscriber will receive all events for the type, exchange, and selector.

```typescript
const subscriber = eventBus.subscribe(eventBusEvent, onData)
// will get events

// Somewhere else in the code
subscriber()
// will stop getting events
```

A subscriber must be cleaned up or else there is risk of leaking memory since the garbage collector won't be able to free up the memory.

## Gotchas

Neither the register or subscribe functions can be invoked with the selector omitted but the strategy defined.