### PR TITLE
Moved complexity of strategy to base class

### DIFF
--- a/src/conf.sample.ts
+++ b/src/conf.sample.ts
@@ -157,5 +157,5 @@ export const magic8bot: Magic8bot = {
   srcRoot: null,
   version: null,
   loggerLevel: 'debug',
-  loggerFile: 'magic8bot.log',
+  loggerFile: '',
 }

--- a/src/engine/order.ts
+++ b/src/engine/order.ts
@@ -46,7 +46,7 @@ export class OrderEngine {
 
   get wallet() {
     const wallet = this.walletStore.getWallet(this.opts)
-    logger.info({ wallet })
+    logger.verbose(`Available wallet-size on ${this.exchange} (Asset: ${wallet.asset}/Currency: ${wallet.currency}).`)
     return wallet
   }
 

--- a/src/engine/order.ts
+++ b/src/engine/order.ts
@@ -86,7 +86,7 @@ export class OrderEngine {
   }
 
   private async placeOrder(orderOpts: OrderOpts, adjustment: Adjustment) {
-    logger.info('Placing order:', orderOpts)
+    logger.info(`Placing a ${orderOpts.type} ${orderOpts.side}-order of ${orderOpts.amount} at ${orderOpts.price}.`)
 
     try {
       const { exchange } = this.opts
@@ -110,6 +110,7 @@ export class OrderEngine {
     await sleep(this.orderPollInterval)
 
     const { exchange } = this.opts
+    logger.verbose(`Checking order ${id} on ${exchange}`)
     const order = await this.exchangeProvider.checkOrder(exchange, id)
 
     await this.updateOrder(order)

--- a/src/engine/strategy.ts
+++ b/src/engine/strategy.ts
@@ -1,7 +1,7 @@
 import { Balances, Balance } from 'ccxt'
 import { EventBusListener } from '@magic8bot/event-bus'
 
-import { StrategyConf } from '@m8bTypes'
+import { StrategyConf, Signal } from '@m8bTypes'
 import { eventBus, EVENT } from '@lib'
 import { PeriodStore, WalletStore } from '@stores'
 import { BaseStrategy, strategyLoader } from '@strategy'
@@ -15,9 +15,9 @@ export class StrategyEngine {
 
   private strategy: BaseStrategy
   private orderEngine: OrderEngine
-  private lastSignal: 'buy' | 'sell' = null
+  private lastSignal: Signal = null
 
-  private signalListener: EventBusListener<{ signal: 'buy' | 'sell' }>
+  private signalListener: EventBusListener<{ signal: Signal }>
 
   constructor(
     private readonly exchangeProvider: ExchangeProvider,
@@ -60,7 +60,7 @@ export class StrategyEngine {
   }
 
   private onSignal(signal: 'buy' | 'sell', force = false) {
-    logger.info({ signal })
+    logger.info(`${this.strategyName} sent ${signal}-signal (force:${force})`)
     if (!signal || (signal === this.lastSignal && !force)) return
     this.lastSignal = signal
 

--- a/src/strategy/strategies/base-strategy.ts
+++ b/src/strategy/strategies/base-strategy.ts
@@ -1,6 +1,6 @@
 import { PeriodItem, EVENT, eventBus } from '@lib'
 import { EventBusListener, EventBusEmitter } from '@magic8bot/event-bus'
-import { SignalEvent, Signal } from '../../types/index'
+import { SignalEvent, Signal } from '@m8bTypes'
 
 /**
  * This class defines the base functionality of a strategy.
@@ -37,11 +37,13 @@ export abstract class BaseStrategy<TOptions = any, TCalcResult = any> {
   protected calcEmitter: EventBusEmitter<TCalcResult>
 
   constructor(protected readonly name: string, protected exchange: string, protected symbol: string) {
+
     const periodUpdateListener: EventBusListener<PeriodItem[]> = eventBus.get(EVENT.PERIOD_UPDATE)(exchange)(symbol)(this.name).listen
     const periodNewListener: EventBusListener<void> = eventBus.get(EVENT.PERIOD_NEW)(exchange)(symbol)(this.name).listen
+
     periodUpdateListener((periods) => {
       const result = this.calculate(periods)
-      if (result) {
+      if (result && Object.keys(result).length === 0) {
         this.calcEmitter(result)
       }
     })
@@ -77,15 +79,5 @@ export abstract class BaseStrategy<TOptions = any, TCalcResult = any> {
    */
   public prerollDone() {
     this.isPreroll = false
-  }
-
-  // tslint:disable-next-line:no-empty
-  public async init() {
-    // whats its usage?
-  }
-
-  // tslint:disable-next-line:no-empty
-  public async tick() {
-    // whats its usage?
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -118,7 +118,7 @@ export interface Magic8bot {
   srcRoot: string
   debug: boolean
   loggerLevel: 'silly' | 'debug' | 'verbose' | 'info' | 'warn' | 'error'
-  loggerFile: string
+  loggerFile?: string
 }
 
 export interface Quote {

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,5 +1,19 @@
 import winston from 'winston'
 import { magic8bot } from '../conf'
+import * as Transport from 'winston-transport'
+
+function* getWinstonTransports(): IterableIterator<Transport> {
+    const fileLogger = isFileLoggerAvailable()
+    if (fileLogger) {
+        yield new winston.transports.File({ filename: magic8bot.loggerFile })
+    }
+
+    if (process.env.NODE_ENV !== 'production' || !fileLogger) {
+        yield new winston.transports.Console({
+            format: formatter,
+        })
+    }
+}
 
 const textFormat = winston.format.printf((info) => {
     return `${info.timestamp} [${info.level.padStart(5, ' ')}]: ${info.message}`
@@ -12,16 +26,12 @@ const formatter = winston.format.combine(
     textFormat
 )
 
+const isFileLoggerAvailable = () => {
+    return magic8bot.loggerFile && magic8bot.loggerFile.length > 0
+}
+
 export const logger = winston.createLogger({
     level: magic8bot.loggerLevel,
     format: formatter,
-    transports: [
-        new winston.transports.File({ filename: magic8bot.loggerFile }),
-    ],
+    transports: Array.from(getWinstonTransports()),
 })
-
-if (process.env.NODE_ENV !== 'production') {
-    logger.add(new winston.transports.Console({
-        format: formatter,
-    }))
-}


### PR DESCRIPTION
Hi,
I moved more logic from the specific strategy to the base-strategy class, since i see no need to implement that logic all time in every strategy. 
It also removes the "bot internal" logic from the strategy itself, so it could focus on that its for: calculation of indicators and signal triggering.

I also edited the Winston-Logger, because i find it somehow bad in my dev enviroment to get a file logger.
Maybe other people dislike the file logging. Now its an optional field in the config. The util/logger.ts now takes care if there is a file to log available and inserts a console logger instead, if there is no file configuration.

If you require a seperat PR for this, i could also split both, but i somehow came from one refactoring to the other while playing with the bot.
So i will first try it as one PR.... :-)