### PR TITLE
Provide more useful indices for lookups on database

### DIFF
--- a/src/lib/db/db-driver.lib.ts
+++ b/src/lib/db/db-driver.lib.ts
@@ -7,9 +7,14 @@ class DbDriver {
   private db: MongoLib
 
   public async connect(dbType: DbType, dbConfig: MongoConf) {
-    if (dbType === 'mongo') this.db = new MongoLib()
-    else throw new Error(`${dbType} not yet supported.`)
-
+    switch (dbType) {
+      case 'mongo':
+        this.db = new MongoLib()
+        break
+      // Add new database engine support here
+      default:
+        throw new Error(`${dbType} not yet supported.`)
+    }
     await this.db.connect(dbConfig)
     this.db.init()
   }

--- a/src/lib/db/mongo.lib.ts
+++ b/src/lib/db/mongo.lib.ts
@@ -81,29 +81,16 @@ export class MongoLib {
     this.optionCollection.createIndex({ sessionId: 1 })
 
     this.tradeCollection.createIndex({ id: 1 }, { unique: true })
-    this.tradeCollection.createIndex({ exchange: 1 })
-    this.tradeCollection.createIndex({ symbol: 1 })
-    this.tradeCollection.createIndex({ timestamp: 1 })
+    this.tradeCollection.createIndex({ exchange: 1, symbol: 1, timestamp: 1 })
 
-    this.markerCollection.createIndex({ exchange: 1 })
-    this.markerCollection.createIndex({ symbol: 1 })
-    this.markerCollection.createIndex({ to: 1 })
-    this.markerCollection.createIndex({ from: 1 })
+    this.markerCollection.createIndex({ exchange: 1, symbol: 1, to: 1 })
+    this.markerCollection.createIndex({ exchange: 1, symbol: 1, from: 1 })
 
-    this.orderCollection.createIndex({ sessionId: 1 })
-    this.orderCollection.createIndex({ symbol: 1 })
-    this.orderCollection.createIndex({ timestamp: 1 })
+    this.orderCollection.createIndex({ sessionId: 1, exchange: 1, symbol: 1, timestamp: 1 })
 
-    this.walletCollection.createIndex({ sessionId: 1 })
-    this.walletCollection.createIndex({ exchange: 1 })
-    this.walletCollection.createIndex({ symbol: 1 })
-    this.walletCollection.createIndex({ strategy: 1 })
+    this.walletCollection.createIndex({ sessionId: 1, exchange: 1, symbol: 1, strategy: 1 })
 
-    this.adjustmentCollection.createIndex({ sessionId: 1 })
-    this.adjustmentCollection.createIndex({ exchange: 1 })
-    this.adjustmentCollection.createIndex({ symbol: 1 })
-    this.adjustmentCollection.createIndex({ strategy: 1 })
-    this.adjustmentCollection.createIndex({ timestamp: 1 })
+    this.adjustmentCollection.createIndex({ sessionId: 1, exchange: 1, symbol: 1, strategy: 1, timestamp: 1 })
   }
 
   private makeConnectionString(


### PR DESCRIPTION
On a search lookup from mongodatabase there can be only one index applied for search. this index could be compound.
As the lookups are all time including exchange and symbol + other fields its better to store them all in a compount index, which can then be used for a lookup.
Check the explain plan of mongodb for this.