### PR TITLE
Enable custom config parameters for strategyConf to configure a strategy

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,7 @@ export interface Base {
 }
 
 export interface StrategyConf extends Partial<Base> {
+  [key: string]: any
   symbol: string
   strategyName: string
   share: {


### PR DESCRIPTION
Without this entry, we are not able to put "custom" parameter to the config file, as its typechecked.
I would not add it to base, as we are then able to put everything to the config, but only the StrategyConf has a flexible part.