### PR TITLE
Traefik implementation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,7 @@ dist
 node_modules
 .dockerignore
 .gitignore
-travis.yml
+.travis.yml
 CODEOWNERS
 docker-compose.yml
 Dockerfile
@@ -16,3 +16,4 @@ Makefile
 README.md
 jest.config.js
 legacy/
+codecov.yml

--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,23 @@
+# Save a copy of this file as .env
+
+# Database configuration
+MONGO_USER=admin
+MONGO_PASS=password
+
+# you should not need to change these
+MONGO_HOST=localhost
+MONGO_PORT=27017
+MONGO_DB=magic8bot
+
+# This value provides weak security for the magic8bot and adminmongo services using a login form.
+# To generate a connection string for a new username and password, change the defaults set for  
+# MONGO_USER and MONGO_PASS above and replace the value in BASIC_AUTH with the output of the following
+# command. Substitute your new username and password for <my-user> and <password>.
+#
+# echo $(htpasswd -nb <my-user> <password>) 
+#
+BASIC_AUTH=admin:$apr1$ug5symze$iJSOWbYv8bK.7GSVyC6Bh/
+
+# Traefik onfiguration for Docker users
+TRAEFIK_DOMAIN=docker.localhost
+TRAEFIK_NETWORK=magic8bot_web

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update && \
     python2-dev && python2 && \
     apk add bash
 
-# Change to app direcotry
+# Change to app directory
 WORKDIR /app
 
 # Fetch and compile ta-lib
@@ -27,16 +27,16 @@ RUN wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz \
 # so we must copy into a volume.
 COPY . /app
 
-# Fix files molested by Windows
-RUN find . -type f -print0 | xargs -0 dos2unix && npm i -g yarn
-RUN  sed -i "s|host: 'localhost'|host: 'mongodb'|g" src/conf.sample.ts
-# Install dependencies and build the bot
-RUN yarn install && yarn build 
-# Remove build tools
-RUN apk del build-dependencies && rm -rf /var/cache/apk/*
+# Create conf.ts - Delete when #207 is complete
+RUN cp src/conf.sample.ts src/conf.ts \
+    && sed -i "s|host: 'localhost'|host: 'mongodb'|g" src/conf.ts
 
-# Expose a port
-EXPOSE 9999
+    # Fix files molested by Windows
+RUN find . -type f -print0 | xargs -0 dos2unix && npm i -g yarn \
+    # Install dependencies and build the bot
+    && yarn install && yarn build \
+    # Remove build tools
+    && apk del build-dependencies && rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,63 @@
+##########################
+# General purpose commands
+##########################
+
+##############################################################
+# Argument fix workaround
+# This allows arguments that start with a hyphen
+# to be used with make targets
+#
+# To use flags with make, execute:
+# make -- <command> <flags>
+# EG:
+# make -- logs --details
+#
+# The double hyphens can be omitted for arguments
+# make <command> <arg>
+# EG:
+# make logs server
+##############################################################
+%:
+	@:
+ARGS = $(filter-out $@,$(MAKECMDGOALS))
+MAKEFLAGS += --silent
+
+# Get the root dir of this file
+ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+# Define the full path to this file
+THIS_FILE := $(lastword $(MAKEFILE_LIST))
+
+# # Find or create a home for sensitive environment variables
+# CREDS=$(HOME)/.credentials
+# ifneq ("$(wildcard $(CREDS))","")
+# CREDENTIALS := $(CREDS)
+# else
+# $(info $(shell "mkdir" $(CREDS)))
+# endif
+
+# # create .env from .env-sample if .env does not exist
+# FILE := $(ROOT_DIR)/.env
+# FILE_TEMPLATE := $(ROOT_DIR)/.env-sample
+# ifneq ("$(wildcard $(FILE))","")
+# # $(info "file exists")
+# else
+# # $(info "file does not exist")
+# $(shell "cp" $(FILE_TEMPLATE) $(FILE))
+# endif
+
+########################################################
+# Quieting make
+# The hyphen preceding target commands instructs make to continue after errors
+# 2> /dev/null suppresses error messages  
+########################################################
+# Suppress echoing commands
+.SILENT:
+
+# list available make commands
+list:
+	sh -c "echo; $(MAKE) -p no_targets__ | awk -F':' '/^[a-zA-Z0-9][^\$$#\/\\t=]*:([^=]|$$)/ {split(\$$1,A,/ /);for(i in A)print A[i]}' | grep -v '__\$$' | grep -v 'Makefile'| sort"
+
 ########################################################
 # Configuration options for various Windows environments
 ########################################################
@@ -23,87 +83,84 @@
 # HOME := $(subst \,/,$(HOME))
 # endif
 
-# Get the root dir of this file
-ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+#############################
+# Application commands
+#############################
 
-# Define the full path to this file
-THIS_FILE := $(lastword $(MAKEFILE_LIST))
-
-###########################################################
-# Find or create a home for sensitive environment variables
-###########################################################
-
-# CREDS=$(HOME)/.credentials
-# ifneq ("$(wildcard $(CREDS))","")
-# CREDENTIALS := $(CREDS)
-# else
-# $(info $(shell "mkdir" $(CREDS)))
+# # Find or create a home for jupyter custom settings
+# SETTINGS_DIR=$(HOME)/.magic8bot
+# ifneq ("$(wildcard $(SETTINGS_DIR))","")
+# else 
+# $(info $(shell "mkdir" $(SETTINGS_DIR)))
 # endif
+# SETTINGS := $(SETTINGS_DIR)
 
-#############################
-# Argument fix workaround
-# To use arguments with make, execute:
-# make -- <command> <args>
-#############################
-%:
-	@:
-ARGS = $(filter-out $@,$(MAKECMDGOALS))
-MAKEFLAGS += --silent
+# image name to use in the format org/name:tag
+APP_IMAGE=magic8bot/magic8bot
 
-#############################
-# magic8bot
-#############################
+# container name to use for app
+APP_NAME=magic8bot
 
+# # named volume used by app
+# NAMED_VOL=envs_vol
 
+# Docker command to launch the app.
+# leave blank if using docker-compose.yml
+# app_up : 
+# 	echo "Creating environment. This may take a few minutes..."
+# 	docker run -it \
+# 	--name $(APP_NAME) \
+# 	--mount type=bind,source=${PWD}/projects,target=/root/projects \
+# 	--mount type=bind,source=$(SETTINGS),target=/root/user-settings \
+# 	--mount type=bind,source=$(CREDENTIALS),target=/root/credentials \
+# 	--mount type=volume,source=$(NAMED_VOL),target=/opt/conda/envs \
+# 	-p 8888:8888/tcp  $(APP_IMAGE)
+# 	echo "Environment created. Jupyter Lab is available at https://localhost:8888"
+
+# rm_app_vols:
+# 	docker volume rm -f $(NAMED_VOL) 
 #############################
 # Docker commands
 #############################
 
-# list available make commands  
-list:
-	sh -c "echo; $(MAKE) -p no_targets__ | awk -F':' '/^[a-zA-Z0-9][^\$$#\/\\t=]*:([^=]|$$)/ {split(\$$1,A,/ /);for(i in A)print A[i]}' | grep -v '__\$$' | grep -v 'Makefile'| sort"
+# Build app image as defined in Dockerfile
+build:
+	echo "Building image..."
+	docker build -t $(APP_IMAGE) . $(ARGS)
 
-# build app as defined in docker-compose.yml  
+# build app as defined in docker-compose.yml or app_up target
 up:
-	docker-compose up -d
-
+	-$(MAKE) -f $(THIS_FILE) stop
+	-docker rm -f $(APP_NAME) 2> /dev/null
+	docker-compose up -d 2> /dev/null || $(MAKE) -f $(THIS_FILE) build && $(MAKE) -f $(THIS_FILE) app_up
+	
 # stop app without losing data  
 stop:
-	docker-compose stop
+	docker-compose stop 2> /dev/null || docker stop $(APP_NAME)
 
 # start app  
 start:
-	docker-compose start
-
-# build Docker images defined in docker-compose.yml  
-build:
-	docker build -t magic8bot .
+	docker-compose start 2> /dev/null || docker start $(APP_NAME)   
 
 # stop and delete all local Docker objects but keep downloaded images
 # ALL DATA WILL BE DELETED
-re-build:
-	-docker-compose down --rmi local -v
-	docker-compose up -d --build
+rebuild:
+	-docker-compose down --rmi local -v --remove-orphans 2> /dev/null
+	docker-compose up -d --build 2> /dev/null || $(MAKE) -f $(THIS_FILE) -- build --no-cache
 
 # stop and delete all Docker objects defined in docker-compose.yml  
 # ALL DATA WILL BE DELETED 
 destroy:
-	-docker-compose stop
-	-docker-compose rm --force server
-	-docker-compose rm --force mongodb
-	-docker-compose rm --force adminmongo
-	-docker rmi magic8bot
-	-docker rmi mongo
-	-docker rmi mrvautin/adminmongo
-	-docker rmi node:10-alpine
-	docker volume prune --force
-	docker system prune --force
+	-docker-compose down --rmi all -v --remove-orphans 2> /dev/null || $(MAKE) -f $(THIS_FILE) stop && docker rm $(APP_NAME)
+	-docker rmi -f $(APP_IMAGE)
+	-$(MAKE) -f $(THIS_FILE) rm_app_vols
+	$(MAKE) -f $(THIS_FILE) prune
 
 # show status of Docker objects defined in docker-compose.yml  
 state:
 	@echo
 	@echo ***Containers***
-	docker-compose ps
+	docker ps
 	@echo
 	@echo ***Volumes***
 	docker volume ls 
@@ -111,17 +168,24 @@ state:
 	@echo ***Networks***
 	docker network ls 
 
+# Prune unused volumes and images
+prune :
+	docker volume prune -f
+	docker image prune -f
+	docker system prune -f
+
 # show Docker logs  
 logs:
-	docker-compose logs $(ARGS)
+	$(DOCKER_CMD) logs $(ARGS)
 
 # open a shell in the application container  
-shell:
-	docker-compose exec server /bin/sh
+shell :
+	-@$(MAKE) -f $(THIS_FILE) start
+	docker exec -i -t $(APP_NAME) /bin/bash
 
 # open a shell in the application container as admin user  
 shellw:
-	docker exec -it -u root $$(docker-compose ps -q server) /bin/sh
+	docker exec -it -u root $$(docker-compose ps -q $(APP_NAME)) /bin/sh
 
 # sync clock in container with host's clock
 time-sync:

--- a/Makefile
+++ b/Makefile
@@ -79,22 +79,37 @@ start:
 build:
 	docker build -t magic8bot .
 
-# ALL DATA WILL BE DELETED  
+# stop and delete all local Docker objects but keep downloaded images
+# ALL DATA WILL BE DELETED
+re-build:
+	-docker-compose down --rmi local -v
+	docker-compose up -d --build
+
 # stop and delete all Docker objects defined in docker-compose.yml  
+# ALL DATA WILL BE DELETED 
 destroy:
 	-docker-compose stop
 	-docker-compose rm --force server
 	-docker-compose rm --force mongodb
 	-docker-compose rm --force adminmongo
-	-docker rmi magic8bot:latest
+	-docker rmi magic8bot
 	-docker rmi mongo
-	-docker rmi adminmongo
+	-docker rmi mrvautin/adminmongo
+	-docker rmi node:10-alpine
 	docker volume prune --force
 	docker system prune --force
 
 # show status of Docker objects defined in docker-compose.yml  
 state:
+	@echo
+	@echo ***Containers***
 	docker-compose ps
+	@echo
+	@echo ***Volumes***
+	docker volume ls 
+	@echo
+	@echo ***Networks***
+	docker network ls 
 
 # show Docker logs  
 logs:

--- a/README.md
+++ b/README.md
@@ -79,8 +79,12 @@ make start
 # build Docker images defined in docker-compose.yml  
 make build  
 
-# ALL DATA WILL BE DELETED  
+# stop and delete all local Docker objects but keep downloaded images
+# ALL DATA WILL BE DELETED
+re-build
+
 # stop and delete all Docker objects defined in docker-compose.yml  
+# ALL DATA WILL BE DELETED
 make destroy  
 
 # show status of Docker objects defined in docker-compose.yml  

--- a/README.md
+++ b/README.md
@@ -46,20 +46,22 @@ Purple: Blunt end of line is directly injected into the arrow end of line
 
 ### Docker Integration
 
-Magic8bot can be run in a container. This is advantageous to users who don't want to install node dependencies locally or want to deploy the app on a server. The only prerequisite is Docker.  
+Magic8bot can be run in a container. This is advantageous to users who don't want to install node dependencies locally or want to deploy the app on a server. The only prerequisite is Docker. Note that `port 80` must be available.  
 
 #### Docker installation
 
-* Install [Docker](https://www.docker.com/community-edition)  
-* Download or clone magic8bot to your machine
-* Copy `src/conf.sample.ts` to `src/conf.ts`  
-* In `src/conf.ts` change `mongoconf` host from `localhost` to `mongodb`  
-* From the root of the repo directory, execute the `up` command as described below
+- Install [Docker](https://www.docker.com/community-edition)  
+- Download or clone magic8bot to your machine
+- Copy `.env-sample` to `.env`
+- From the root of the repo directory, execute the `up` command as described below
 
 #### Docker Usage
 
 Interacting with an instance of magic8bot running in a container can be cumbersome. A `Makefile` is provided to simplify executing commands. WSL, Linux and Mac users will likely be able to use this feature without difficulty. Most Windows users will need to install `Make`.  
 Once `make --v` can be executed successfully, Docker commands can be run with the syntax `make -- <command> <arguments>`. The two dashes are annoying but necessary to enable arguments that begin with a hyphen.  Available commands can be listed with `make list`.  Alternatively, Docker commands can be run as listed in the make targets. For example, `make up` == `docker-compose up -d`  
+
+[Traefik](https://traefik.io/) is implemented as a reverse-proxy / load balancer. This configuration requires that `port 80` is available. For more information about the issue see [this question](https://stackoverflow.com/questions/1430141/port-80-is-being-used-by-system-pid-4-what-is-that).  
+TLDR: Windows users can run `net stop http` in Powershell as an admin.
 
 **The following commands are supported:**  
 
@@ -81,7 +83,7 @@ make build
 
 # stop and delete all local Docker objects but keep downloaded images
 # ALL DATA WILL BE DELETED
-re-build
+rebuild
 
 # stop and delete all Docker objects defined in docker-compose.yml  
 # ALL DATA WILL BE DELETED
@@ -89,6 +91,9 @@ make destroy
 
 # show status of Docker objects defined in docker-compose.yml  
 make state  
+
+# Prune unused volumes and images
+make prune
 
 # show Docker logs  
 make logs  
@@ -101,6 +106,49 @@ make shellw
 
 # sync clock in container with host's clock
 make time-sync  
+```
+
+#### Docker configuration  
+
+Configuration variables for the app are set in `.env`.  
+
+
+```bash
+# Database defaults
+MONGO_USER=admin
+MONGO_PASS=password
+
+# you should not need to change these
+MONGO_HOST=localhost
+MONGO_PORT=27017
+MONGO_DB=magic8bot
+```  
+
+The database credentials are also used to secure a login form for the docker services. To generate a new connection string after changing the defaults set for `MONGO_USER` and `MONGO_PASS`, replace the value in `BASIC_AUTH` with the output of the following command substituting your new username and password for `<my-user>` and `<password>`.
+
+```bash
+echo $(htpasswd -nb <my-user> <password>)  
+```
+
+#### Traefik configuration for Docker users  
+
+```bash
+BASIC_AUTH=admin:$apr1$ug5symze$iJSOWbYv8bK.7GSVyC6Bh/
+TRAEFIK_DOMAIN=docker.localhost
+TRAEFIK_NETWORK=magic8bot_web
+```
+
+The service address are set with `TRAEFIK_DOMAIN`. For example:  
+
+```bash
+# Magic8bot
+magic8bot.docker.localhost  
+
+# Adminmongo
+db.docker.localhost  
+
+# Traefik
+traefik.docker.localhost
 ```
 
 ## Donate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,59 @@
-version: '3.1'
+version: '3.5'
 services:
+
+  traefik:
+    container_name: traefik
+    image: traefik
+    command: --web --docker --docker.domain=${TRAEFIK_DOMAIN} --logLevel=DEBUG
+    restart: always
+    networks:
+      - web
+    ports:
+      - "80:80"
+      - "8080:8080"
+    expose:
+      - 80
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # So that Traefik can listen to the Docker events
+      - /dev/null:/traefik.toml
+    labels:
+      - "traefik.docker.network=web"
+      - "traefik.enable=true"
+      - "traefik.frontend.rule=Host:traefik.${TRAEFIK_DOMAIN}"
+      - "traefik.frontend.auth.basic=${BASIC_AUTH}"
+      - "traefik.port=8080"
+
+  # TESTING SERVICE - This service can be deleted when m8b has a front-end. 
+  whoami:
+    image: emilevauge/whoami # A container that exposes an API to show its IP address
+    networks:
+      - web
+    labels:
+      - "traefik.docker.network=web"
+      - "traefik.enable=true"
+      - "traefik.frontend.rule=Host:whoami.${TRAEFIK_DOMAIN}"
+      - "traefik.frontend.auth.basic=${BASIC_AUTH}"
+
   server:
+    container_name: magic8bot
     build:
       context: .
       dockerfile: Dockerfile
     image: magic8bot
-    volumes:
-      - /app
-    ports:
-      - "9999:9999"
-    expose: 
-      - 9999
     depends_on:
       - mongodb
+    volumes:
+      - /app
+    networks:
+      - web
+      - internal
+    labels: 
+      - "traefik.docker.network=${TRAEFIK_NETWORK}"
+      - "traefik.enable=true"
+      - "traefik.frontend.rule=Host:magic8bot.${TRAEFIK_DOMAIN}"
+      - "traefik.frontend.auth.basic=${BASIC_AUTH}"
     environment:
-      - MONGODB_PORT_27017_TCP_ADDR=mongodb
+      - MONGODB_PORT_27017_TCP_ADDR=${MONGO_HOST}
 
   mongodb:
     image: mongo:latest
@@ -22,21 +61,38 @@ services:
       - database:/data/db
     command: mongod --smallfiles --bind_ip=0.0.0.0 --logpath=/dev/null
     expose:
-      - 27017
+      - ${MONGO_PORT}
+    networks: 
+      - internal
+    labels:
+      - "traefik.enable=false"
 
 # AdminMongo is a Web based user interface for MongoDB administration
   adminmongo:
-   image: mrvautin/adminmongo
-   links:
-     - mongodb
-   tty: true
-   ports:
-     - "1234:1234"
-   environment:
-     - CONN_NAME=magic8bot_mongodb
-     - DB_HOST=mongodb
-     - DB_PORT=27017
-   command: "npm start"
+    image: mrvautin/adminmongo
+    links:
+      - mongodb
+    networks:
+      - web
+      - internal
+    labels:
+      - "traefik.backend=adminmongo"
+      - "traefik.docker.network=${TRAEFIK_NETWORK}"
+      - "traefik.frontend.rule=Host:db.${TRAEFIK_DOMAIN}"
+      - "traefik.enable=true"
+      - "traefik.frontend.auth.basic=${BASIC_AUTH}"
+      - "traefik.port=1234"
+    environment:
+      - CONN_NAME=magic8bot_mongodb
+      - DB_HOST=mongodb
+      - DB_PORT=${MONGO_PORT}
+    command: "npm start"
 
 volumes: 
   database:
+
+networks:
+  web:
+    driver: bridge
+  internal:
+    external: false


### PR DESCRIPTION
This implements Traefik as docker reverse proxy. 
- Service parameters are set in `.env` which must exist before building the application. `.env-sample` is provided. This will need to be addressed in #132.

- `conf.ts` is copied in Dockerfile and will clobber any existing version. When #207 is implemented this run step can be removed.

- Containerized services are protected with a login prompt using `traefik.frontend.auth.basic` using `MONGO_USER` and `MONGO_PASS`. Creating a new value for `BASIC_AUTH` should be automated in #207 and #113 using docker secrets.