### PR TITLE
Publish Periods by a nodejs-timer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@magic8bot/event-bus": "^1.0.3",
-    "@magic8bot/timebucket": "^1.0.0",
+    "@magic8bot/timebucket": "^1.1.0",
     "ccxt": "^1.12.97",
     "codecov": "^3.0.4",
     "cross-env": "5.2.0",

--- a/src/core/strategy.ts
+++ b/src/core/strategy.ts
@@ -56,8 +56,9 @@ export class StrategyCore {
   }
 
   public run() {
-    logger.info(`Starting Strategy ${this.strategyName}`)
     this.strategy.prerollDone()
+    PeriodStore.instance.startPeriodEmitter({ exchange: this.exchangeName, symbol: this.symbol, strategy: this.strategyName })
+    logger.info(`Starting Strategy ${this.strategyName}`)
   }
 
   private onSignal(signal: 'buy' | 'sell', force = false) {

--- a/src/strategy/strategies/macd/macd.spec.ts
+++ b/src/strategy/strategies/macd/macd.spec.ts
@@ -172,5 +172,11 @@ describe('Macd', () => {
     it('macd w/o periods', () => {
       expect(macd.calculate([])).toBeUndefined()
     })
+
+    it('test', () => {
+      const baseRsiMockReturn = { avgGain: null, avgLoss: null }
+      mockRsiCalculate.mockReturnValueOnce({ rsi: 80, ...baseRsiMockReturn })
+      expect(macd.calculate(candles.slice(0, 1))).toEqual({ rsi: 80, signal: null })
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,9 +20,9 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@magic8bot/event-bus/-/event-bus-1.0.3.tgz#e0c83650f31332f33f71a4ac0dd7982f8806fae9"
 
-"@magic8bot/timebucket@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@magic8bot/timebucket/-/timebucket-1.0.0.tgz#621c623020c3be48af002c9bb3b93e184caa620b"
+"@magic8bot/timebucket@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@magic8bot/timebucket/-/timebucket-1.1.0.tgz#088a54445e675701024a50bbbf67c85b90456d3d"
   dependencies:
     moment "2.22.2"
 


### PR DESCRIPTION
Periods are now published by a timer instead on the next trade, whichs time is after bucket-endtime.
Due this periods are better aligned to the market and we now support periods w/o any trade at all.

Maybe a bit hacky code, but its working for me.