### PR TITLE
Refactored strategyloader  to load dynamic modules from the strategy folder.

### DIFF
--- a/src/strategy/strategies/index.ts
+++ b/src/strategy/strategies/index.ts
@@ -1,12 +1,14 @@
-import { Macd } from './macd'
-
+import { logger } from '@util'
 export const strategyLoader = (strategyName: string) => {
-  switch (strategyName) {
-    case 'macd':
-      return Macd
-
-    default:
-      throw new Error(`${strategyName} not implemented yet.`)
+  try {
+    if (strategyName === null || strategyName === undefined || !strategyName.length) throw new Error('No strategy given.')
+    logger.verbose(`Loading ${strategyName}....`)
+    const strategyModule = require(`./${strategyName}`)
+    if (!strategyModule.strategy) throw Error("Wrong exported strategy. Export Strategy as field 'strategy'.")
+    logger.silly(`Loaded ${strategyName} successfully.`)
+    return strategyModule.strategy
+  } catch (e) {
+    throw new Error(`Strategy-Module ${strategyName} has thrown an error when loaded! Error-Message: ${e}`)
   }
 }
 

--- a/src/strategy/strategies/macd/index.ts
+++ b/src/strategy/strategies/macd/index.ts
@@ -1,2 +1,5 @@
-export * from './macd'
-export * from './phenotypes'
+import { MacdPhenotypes } from './phenotypes'
+import { Macd } from './macd'
+
+export const strategy = Macd
+export const phenotypes = MacdPhenotypes


### PR DESCRIPTION
A strategy has to export the strategy itself as variable strategy to the module context.

i know the throw -catch throw chain is a bit hacky but its nicely  concatenating error messages together for known and unknown exceptions.