### PR TITLE
Remove Pre-Roll-Logic from StrategyImpl

### DIFF
--- a/src/strategy/strategies/base-strategy.ts
+++ b/src/strategy/strategies/base-strategy.ts
@@ -63,7 +63,7 @@ export abstract class BaseStrategy<TOptions = any, TCalcResult = any> {
     /* istanbul ignore next */
     periodNewListener(() => {
       const signal = this.onPeriod()
-      if (signal) {
+      if (signal && !this.isPreroll) {
         this.signalEmitter({ signal })
       }
     })

--- a/src/strategy/strategies/macd/macd.ts
+++ b/src/strategy/strategies/macd/macd.ts
@@ -176,12 +176,12 @@ export class Macd extends BaseStrategy<MacdOptions, { rsi: number; signal: numbe
     this.periods[0].avgGain = avgGain
 
     this.periods[0].avgLoss = avgLoss
-    this.overbought = !this.isPreroll && rsi >= this.options.overboughtRsi && !this.overbought
+    this.overbought = rsi >= this.options.overboughtRsi && !this.overbought
   }
 
   public onPeriod() {
     /* istanbul ignore next */
-    const signal = this.isPreroll ? null : this.overboughtSell() ? 'sell' : this.getSignal()
+    const signal = this.overboughtSell() ? 'sell' : this.getSignal()
     /* istanbul ignore next */
     if (this.periods.length) {
       logger.verbose(


### PR DESCRIPTION
As its a un-needed complexity in a Strategy implementation i would prefer to remove the preroll logic from those.
As its only preventing the signal, i would just move it as gate to the signal publish.
Due this this logic is completely hidden for a strategy, which should not care for those internal logics.